### PR TITLE
Allow conversations by saving context to a user-specific session

### DIFF
--- a/src/hubot-wit.js
+++ b/src/hubot-wit.js
@@ -81,11 +81,10 @@ module.exports = function(robot) {
 
     const client = new Wit({accessToken: WIT_TOKEN, actions});
 
-    client.runActions(findOrCreateSession(res.message.user["id"]), query, context)
+    client.runActions(sessionId, query, context)
       .then((ctx) => {
         context = ctx;
         // Save Context
-        sessionId = findOrCreateSession(res.message.user["id"]);
         sessions[sessionId].context = ctx;
       })
       .catch(err => console.error(err))

--- a/src/hubot-wit.js
+++ b/src/hubot-wit.js
@@ -51,7 +51,8 @@ module.exports = function(robot) {
 
   robot.respond(/(.*)/i, function(res) {
     const query = res.match[1];
-    sessionId = findOrCreateSession(res.message.user["id"]);
+    const sessionId = findOrCreateSession(res.message.user["id"]);
+    let context = {};
     if (sessions[sessionId].context !== {}) {
       context = sessions[sessionId].context;
     }

--- a/src/hubot-wit.js
+++ b/src/hubot-wit.js
@@ -15,6 +15,7 @@
 
 const {Wit, log, interactive} = require('node-wit');
 const WIT_TOKEN = process.env.WIT_TOKEN;
+const sessions = {};
 
 module.exports = function(robot) {
 
@@ -30,9 +31,30 @@ module.exports = function(robot) {
     return typeof val === 'object' ? val.value : val;
   };
 
+  const findOrCreateSession = (userid) => {
+    let sessionId;
+    // Let's see if we already have a session for the user userid
+    Object.keys(sessions).forEach(k => {
+      if (sessions[k].userid === userid) {
+        // Yep, got it!
+        sessionId = k;
+      }
+    });
+    if (!sessionId) {
+      // No session found for user userid, let's create a new one
+      // Also possible to create a sessionId depending on the Date, e.g.: sessionId = new Date().toISOString();
+      sessionId = "session-" + userid;
+      sessions[sessionId] = {userid: userid, context: {}};
+    }
+    return sessionId;
+  };
+
   robot.respond(/(.*)/i, function(res) {
     const query = res.match[1];
-    let context = {};
+    sessionId = findOrCreateSession(res.message.user["id"]);
+    if (sessions[sessionId].context !== {}) {
+      context = sessions[sessionId].context;
+    }
 
     const actions = {
       send(request, response) {
@@ -59,9 +81,12 @@ module.exports = function(robot) {
 
     const client = new Wit({accessToken: WIT_TOKEN, actions});
 
-    client.runActions("session-" + res.message.user["id"], query, context)
+    client.runActions(findOrCreateSession(res.message.user["id"]), query, context)
       .then((ctx) => {
         context = ctx;
+        // Save Context
+        sessionId = findOrCreateSession(res.message.user["id"]);
+        sessions[sessionId].context = ctx;
       })
       .catch(err => console.error(err))
 


### PR DESCRIPTION
Without saving the context into an array of sessions the context gets reseted every time the user writes something to Hubot. (`let context = {};`)

